### PR TITLE
Enable stripping of bundle by default

### DIFF
--- a/bundling.cmake
+++ b/bundling.cmake
@@ -13,7 +13,6 @@ set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 
 # bundling
 # FIXME (aw): in case of dist folder, we could only clean up the dist folder
-# FIXME (aw): we need add stripping
 
 add_custom_target(bundle
     COMMAND "${CMAKE_COMMAND}" -E remove_directory ${CMAKE_BINARY_DIR}/bundle
@@ -21,6 +20,7 @@ add_custom_target(bundle
     COMMAND "${CMAKE_COMMAND}"
         -E env DESTDIR=bundle
         "${CMAKE_COMMAND}" --install "${CMAKE_BINARY_DIR}"
+        $<$<NOT:$<BOOL:${EVEREST_CMAKE_DISABLE_STRIPPING_BUNDLE}>>:--strip>
     COMMAND rm -rf
         bundle/${CMAKE_INSTALL_PREFIX}/include
         bundle/${CMAKE_INSTALL_PREFIX}/lib/cmake


### PR DESCRIPTION
- previously, the installed files for the *make bundle* target haven't been stripped - now thats the default
- using the flag EVEREST_CMAKE_DISABLE_STRIPPING_BUNDLE, stripping of the files for the bundle target can be disabled