### PR TITLE
Change Python3_FIND_VIRTUALENV from FIRST to ONLY

### DIFF
--- a/python-virtualenv.cmake
+++ b/python-virtualenv.cmake
@@ -50,7 +50,7 @@ macro(ev_activate_python_venv)
         message(FATAL_ERROR "Directory is not a python venv: ${EV_ACTIVATE_PYTHON_VENV_PATH_TO_VENV}")
     endif()
     set(ENV{VIRTUAL_ENV} "${EV_ACTIVATE_PYTHON_VENV_PATH_TO_VENV}")
-    set(Python3_FIND_VIRTUALENV FIRST)
+    set(Python3_FIND_VIRTUALENV ONLY)
     unset(Python3_EXECUTABLE)
     find_package(Python3
         REQUIRED


### PR DESCRIPTION
This ensures that the following find_package only considers the venv and not look in other paths for a suitable
Interpreter/Development header combination